### PR TITLE
Random audio selection and padding as required

### DIFF
--- a/audiolm_pytorch/data.py
+++ b/audiolm_pytorch/data.py
@@ -51,6 +51,15 @@ class SoundDataset(Dataset):
         file = self.files[idx]
 
         data, sample_hz = torchaudio.load(file)
+        
+        if data.size(1) >= self.max_length:
+            max_start = data.size(1) - self.max_length
+            start = torch.randint(0, max_start, (1, ))
+            data = data[:, start:start + self.max_length]
+
+        else:
+            data = torch.nn.functional.pad(data, (self.max_length - data.size(1), 0), 'constant')
+        
         data = rearrange(data, '1 ... -> ...')
 
         num_outputs = len(self.target_sample_hz)


### PR DESCRIPTION
Currently we always take the beginning of the audio file up to `max_length`. This prevents us from making full use of the data (especially when dealing with lots of long audio files). This change selects random parts of the audio file rather than always cropping from the start. It also pads audio files shorter than `max_length`.  Feel free to re-work this but you get the idea.