### PR TITLE
Fix potential AssertionError

### DIFF
--- a/audiolm_pytorch/trainer.py
+++ b/audiolm_pytorch/trainer.py
@@ -103,7 +103,7 @@ def determine_types(data, config):
         else:
             raise TypeError(f'unable to determine type of {data}')
 
-    return tuple(output)
+    return tuple(set(output))
 
 # main trainer class
 


### PR DESCRIPTION
I'm not 100% sure this is the right fix, but without this and a batch_size > 1, this method was returning e.g. ('raw_wave', 'raw_wave') and triggered the following assertion error:

Traceback (most recent call last):
  File "train_semantic.py", line 18, in <module>
    trainer.train()
  File "/mnt/c/audio-ml-workspace/audiolm/audiolm_pytorch/trainer.py", line 577, in train
    logs = self.train_step()
  File "/mnt/c/audio-ml-workspace/audiolm/audiolm_pytorch/trainer.py", line 533, in train_step
    data_kwargs = self.data_tuple_to_kwargs(next(self.dl_iter))
  File "/mnt/c/audio-ml-workspace/audiolm/audiolm_pytorch/trainer.py", line 515, in data_tuple_to_kwargs
    assert not has_duplicates(self.ds_fields), 'dataset fields must not have duplicate field names'
AssertionError: dataset fields must not have duplicate field names