### PR TITLE
Fix target_sample_hz typing for other uses

### DIFF
--- a/audiolm_pytorch/hubert_kmeans.py
+++ b/audiolm_pytorch/hubert_kmeans.py
@@ -28,7 +28,7 @@ class HubertWithKmeans(nn.Module):
         self,
         checkpoint_path,
         kmeans_path,
-        target_sample_hz = 50000,
+        target_sample_hz: Optional[Tuple[Optional[int], ...]]  = (50000,),
         seq_len_multiple_of = None
     ):
         super().__init__()

--- a/audiolm_pytorch/hubert_kmeans.py
+++ b/audiolm_pytorch/hubert_kmeans.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from beartype import beartype
+from beartype.typing import Tuple, Union, Optional
 
 import torch
 from torch import nn
@@ -18,6 +20,7 @@ logging.root.setLevel(logging.ERROR)
 def exists(val):
     return val is not None
 
+@beartype
 class HubertWithKmeans(nn.Module):
     """
     checkpoint and kmeans can be downloaded at https://github.com/facebookresearch/fairseq/tree/main/examples/hubert

--- a/audiolm_pytorch/soundstream.py
+++ b/audiolm_pytorch/soundstream.py
@@ -1,6 +1,8 @@
 import functools
 from pathlib import Path
 from functools import partial
+from beartype import beartype
+from beartype.typing import Tuple, Union, Optional
 
 import torch
 from torch import nn, einsum

--- a/audiolm_pytorch/soundstream.py
+++ b/audiolm_pytorch/soundstream.py
@@ -266,7 +266,7 @@ class SoundStream(nn.Module):
         adversarial_loss_weight = 1.,
         feature_loss_weight = 100,
         quantize_dropout_cutoff_index = 1,
-        target_sample_hz = 24000,
+        target_sample_hz: Optional[Tuple[Optional[int], ...]] = (24000,),
         attn_window_size = 128,
         attn_dim_head = 64,
         attn_heads = 8

--- a/audiolm_pytorch/soundstream.py
+++ b/audiolm_pytorch/soundstream.py
@@ -250,6 +250,7 @@ def DecoderBlock(chan_in, chan_out, stride):
         ResidualUnit(chan_out, chan_out, 9),
     )
 
+@beartype
 class SoundStream(nn.Module):
     def __init__(
         self,

--- a/audiolm_pytorch/vq_wav2vec.py
+++ b/audiolm_pytorch/vq_wav2vec.py
@@ -27,7 +27,7 @@ class FairseqVQWav2Vec(nn.Module):
     def __init__(
         self,
         checkpoint_path,
-        target_sample_hz = 24000,
+        target_sample_hz: Optional[Tuple[Optional[int], ...]]  = (24000,),
         seq_len_multiple_of = None
     ):
         super().__init__()

--- a/audiolm_pytorch/vq_wav2vec.py
+++ b/audiolm_pytorch/vq_wav2vec.py
@@ -18,6 +18,7 @@ logging.root.setLevel(logging.ERROR)
 def exists(val):
     return val is not None
 
+@beartype
 class FairseqVQWav2Vec(nn.Module):
     """
     checkpoint path can be found at https://github.com/facebookresearch/fairseq/blob/main/examples/wav2vec/README.md#vq-wav2vec

--- a/audiolm_pytorch/vq_wav2vec.py
+++ b/audiolm_pytorch/vq_wav2vec.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from beartype import beartype
+from beartype.typing import Tuple, Union, Optional
 
 import torch
 from torch import nn


### PR DESCRIPTION
Update the `other target_sample_hz` types following the pattern in release [0.4.3](https://github.com/lucidrains/audiolm-pytorch/releases/tag/0.4.3) (since the default code in the README currently fails as-is, I think because `target_sample_hz` was previously set to a single int).