### PR TITLE
l2norm should compute the norm, not normalize

### DIFF
--- a/audiolm_pytorch/soundstream.py
+++ b/audiolm_pytorch/soundstream.py
@@ -36,7 +36,7 @@ def cast_tuple(t, l = 1):
 # tensor helpers
 
 def l2norm(t, dim = -1):
-    return F.normalize(t, dim = dim)
+    return torch.linalg.vector_norm(t, ord = 2, dim = dim)
 
 # gan losses
 


### PR DESCRIPTION
equation 5 in the [paper](https://arxiv.org/pdf/2107.03312.pdf) computes an l2 norm over the logs of the spectrogram, but the current implementation normalizes it which has a different effect