### PR TITLE
SoundStreamTrainer tweaks

### DIFF
--- a/audiolm_pytorch/soundstream.py
+++ b/audiolm_pytorch/soundstream.py
@@ -585,7 +585,8 @@ class SoundStream(nn.Module):
                 one_discr_loss = hinge_discr_loss(fake_logits, real_logits)
 
                 discr_losses.append(one_discr_loss)
-                discr_grad_penalties.append(gradient_penalty(scaled_real, one_discr_loss))
+                if apply_grad_penalty:
+                    discr_grad_penalties.append(gradient_penalty(scaled_real, one_discr_loss))
 
             if not return_discr_losses_separately:
                 all_discr_losses = torch.stack(discr_losses).mean()

--- a/audiolm_pytorch/trainer.py
+++ b/audiolm_pytorch/trainer.py
@@ -299,7 +299,7 @@ class SoundStreamTrainer(nn.Module):
         device = self.device
 
         steps = int(self.steps.item())
-        apply_grad_penalty = not (steps % self.apply_grad_penalty_every)
+        apply_grad_penalty = self.apply_grad_penalty_every > 0 and not (steps % self.apply_grad_penalty_every)
         log_losses = self.log_losses_every > 0 and not (steps % self.log_losses_every)
 
         self.soundstream.train()


### PR DESCRIPTION
Some `SoundStreamTrainer` improvements:

1. Log all losses through the `Accelerator` to get a better understanding of what is going on during the training;
2. Synchronize gradient penalties for `STFT` and `MultiScaleDiscriminators`;
3. Allow turning off the EMA model with `use_ema` (as done in your other repos);
4. Fix saving of EMA model samples during training.