### PR TITLE
Modify default SoundStream strides to 480 to match default 24kHz sampling rate

### DIFF
--- a/audiolm_pytorch/soundstream.py
+++ b/audiolm_pytorch/soundstream.py
@@ -343,7 +343,7 @@ class SoundStream(nn.Module):
         self,
         *,
         channels = 32,
-        strides = (2, 4, 5, 8),
+        strides = (3, 4, 5, 8),
         channel_mults = (2, 4, 8, 16),
         codebook_dim = 512,
         codebook_size = 1024,


### PR DESCRIPTION
As per discussion at https://github.com/lucidrains/audiolm-pytorch/issues/80, the default `strides` for the `SoundStream` class is set at (2, 4, 5, 8) = 320, which is the strides value found in the AudioLM paper for a 16kHz sampling rate. However, the SoundStream class' default sampling rate (`target_sample_hz`) is 24kHz, for which the MusicLM paper specifies a strides value of 480 (e.g. (3, 4, 5, 8) ). If I haven't missed/or misunderstood something, IMO it'd make sense to have the default `strides` and `target_sample_hz` values in line with one another, hence I've made that change in this PR. Thanks to Afiyetolsun for confirming.