### PR TITLE
Minor patch, couple imports missing

### DIFF
--- a/audiolm_pytorch/encodec.py
+++ b/audiolm_pytorch/encodec.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from torch import nn
 from encodec import EncodecModel
 from encodec.utils import convert_audio, _linear_overlap_add
@@ -36,7 +37,7 @@ class EncodecWrapper(nn.Module):
 
     @property
     def seq_len_multiple_of(self):
-        return functools.reduce(lambda x, y: x * y, self.strides)
+        return reduce(lambda x, y: x * y, self.strides)
 
     def forward(self, x, x_sampling_rate=24000, **kwargs):
         # kwargs for stuff like return_encoded=True, which SoundStream uses but Encodec doesn't

--- a/audiolm_pytorch/encodec.py
+++ b/audiolm_pytorch/encodec.py
@@ -1,4 +1,5 @@
 from functools import reduce
+import torch
 from torch import nn
 from encodec import EncodecModel
 from encodec.utils import convert_audio, _linear_overlap_add

--- a/audiolm_pytorch/encodec.py
+++ b/audiolm_pytorch/encodec.py
@@ -1,4 +1,5 @@
 from functools import reduce
+from einops import rearrange
 import torch
 from torch import nn
 from encodec import EncodecModel

--- a/audiolm_pytorch/trainer.py
+++ b/audiolm_pytorch/trainer.py
@@ -963,7 +963,7 @@ class CoarseTransformerTrainer(nn.Module):
         # save model every so often
 
         if self.is_main and not (steps % self.save_model_every):
-            model_path = str(self.results_folder / f'fine.transformer.{steps}.pt')
+            model_path = str(self.results_folder / f'coarse.transformer.{steps}.pt')
             self.save(model_path)
 
             self.print(f'{steps}: saving model to {str(self.results_folder)}')


### PR DESCRIPTION
Minor bugs

- `functools`, `einops`, and `torch` import missing from `encodec.py`
- Coarse transformer trainer was saving its checkpoints with "fine" in the filename