### PR TITLE
Bug fix in encodec.py

### DIFF
--- a/audiolm_pytorch/encodec.py
+++ b/audiolm_pytorch/encodec.py
@@ -90,7 +90,7 @@ class EncodecWrapper(nn.Module):
         # encoded_frames is a list of (frame, scale) tuples. Scale is a scalar but we don't use it. Frame is a tensor
         # of shape [batch, num_quantizers, num_samples_per_frame]. We want to concatenate the frames to get all the
         # timesteps concatenated.
-        codes = torch.cat([encoded[0] for encoded in encoded_frames], dim=1)  # [batch, num_quantizers, timesteps]
+        codes = torch.cat([encoded[0] for encoded in encoded_frames], dim=-1)  # [batch, num_quantizers, timesteps]
         # transformer code that uses codec expects codes to be [batch, timesteps, num_quantizers]
         codes = rearrange(codes, 'b q n -> b n q')  # result: [batch, timesteps, num_quantizers]
         # in original soundstream, is x, indices, commit_loss. But we only use indices in eval mode, so just keep that.
@@ -100,8 +100,8 @@ class EncodecWrapper(nn.Module):
         emb = None
         if return_encoded:
             emb = self.get_emb_from_indices(codes)
-
-        emb, = unpack(emb, ps, '* n c')
+        if emb:
+            emb, = unpack(emb, ps, '* n c')
         codes, = unpack(codes, ps, '* n q')
 
         return emb, codes, None


### PR DESCRIPTION
Found two bugs in encodec.py
- the concatenation of `encoded` should be last dimension instead of dim=1 (it's num_quantizers).
- if return_encoded is false, exception will be thrown at line `emb, = unpack(emb, ps, '* n c')`, since emb is None.