### PR TITLE
Separate transformer and trainer checkpoint load logic

### DIFF
--- a/audiolm_pytorch/audiolm_pytorch.py
+++ b/audiolm_pytorch/audiolm_pytorch.py
@@ -434,18 +434,6 @@ class Transformer(nn.Module):
 
         return self.norm(x)
 
-    def load(self, path):
-        # Return pkg so that if this function gets called from within a Trainer function call,
-        # the trainer can also access the package loaded from the checkpoint.
-        path = Path(path)
-        assert path.exists()
-        pkg = torch.load(str(path), map_location = 'cpu')
-        # check version
-        if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
-            print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-        self.load_state_dict(pkg['model'])
-        return pkg
-
 # the three hierarchical transformers
 
 class SemanticTransformer(nn.Module):
@@ -510,6 +498,18 @@ class SemanticTransformer(nn.Module):
     @property
     def device(self):
         return next(self.parameters()).device
+
+    def load(self, path):
+        # Return pkg so that if this function gets called from within a Trainer function call,
+        # the trainer can also access the package loaded from the checkpoint.
+        path = Path(path)
+        assert path.exists()
+        pkg = torch.load(str(path), map_location = 'cpu')
+        # check version
+        if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
+            print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
+        self.load_state_dict(pkg['model'])
+        return pkg
 
     def forward_with_cond_scale(
         self,
@@ -652,6 +652,18 @@ class CoarseTransformer(nn.Module):
     @property
     def device(self):
         return next(self.parameters()).device
+
+    def load(self, path):
+        # Return pkg so that if this function gets called from within a Trainer function call,
+        # the trainer can also access the package loaded from the checkpoint.
+        path = Path(path)
+        assert path.exists()
+        pkg = torch.load(str(path), map_location = 'cpu')
+        # check version
+        if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
+            print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
+        self.load_state_dict(pkg['model'])
+        return pkg
 
     def forward_with_cond_scale(
         self,
@@ -882,6 +894,18 @@ class FineTransformer(nn.Module):
     @property
     def device(self):
         return next(self.parameters()).device
+
+    def load(self, path):
+        # Return pkg so that if this function gets called from within a Trainer function call,
+        # the trainer can also access the package loaded from the checkpoint.
+        path = Path(path)
+        assert path.exists()
+        pkg = torch.load(str(path), map_location = 'cpu')
+        # check version
+        if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
+            print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
+        self.load_state_dict(pkg['model'])
+        return pkg
 
     def forward_with_cond_scale(
         self,

--- a/audiolm_pytorch/audiolm_pytorch.py
+++ b/audiolm_pytorch/audiolm_pytorch.py
@@ -504,7 +504,7 @@ class SemanticTransformer(nn.Module):
         # the trainer can also access the package loaded from the checkpoint.
         path = Path(path)
         assert path.exists()
-        pkg = torch.load(str(path), map_location = 'cpu')
+        pkg = torch.load(str(path))
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
@@ -658,7 +658,7 @@ class CoarseTransformer(nn.Module):
         # the trainer can also access the package loaded from the checkpoint.
         path = Path(path)
         assert path.exists()
-        pkg = torch.load(str(path), map_location = 'cpu')
+        pkg = torch.load(str(path))
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
@@ -900,7 +900,7 @@ class FineTransformer(nn.Module):
         # the trainer can also access the package loaded from the checkpoint.
         path = Path(path)
         assert path.exists()
-        pkg = torch.load(str(path), map_location = 'cpu')
+        pkg = torch.load(str(path))
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')

--- a/audiolm_pytorch/audiolm_pytorch.py
+++ b/audiolm_pytorch/audiolm_pytorch.py
@@ -505,11 +505,11 @@ class SemanticTransformer(nn.Module):
         device = self.device
         path = Path(path)
         assert path.exists()
-        pkg = torch.load(str(path))
+        pkg = torch.load(str(path), map_location = device)
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-        self.load_state_dict(pkg['model'], map_location = device)
+        self.load_state_dict(pkg['model'])
         return pkg
 
     def forward_with_cond_scale(
@@ -660,11 +660,11 @@ class CoarseTransformer(nn.Module):
         device = self.device
         path = Path(path)
         assert path.exists()
-        pkg = torch.load(str(path))
+        pkg = torch.load(str(path), map_location = device)
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-        self.load_state_dict(pkg['model'], map_location = device)
+        self.load_state_dict(pkg['model'])
         return pkg
 
     def forward_with_cond_scale(
@@ -903,11 +903,11 @@ class FineTransformer(nn.Module):
         device = self.device
         path = Path(path)
         assert path.exists()
-        pkg = torch.load(str(path))
+        pkg = torch.load(str(path), map_location = device)
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-        self.load_state_dict(pkg['model'], map_location = device)
+        self.load_state_dict(pkg['model'])
         return pkg
 
 

--- a/audiolm_pytorch/audiolm_pytorch.py
+++ b/audiolm_pytorch/audiolm_pytorch.py
@@ -502,13 +502,14 @@ class SemanticTransformer(nn.Module):
     def load(self, path):
         # Return pkg so that if this function gets called from within a Trainer function call,
         # the trainer can also access the package loaded from the checkpoint.
+        device = self.device
         path = Path(path)
         assert path.exists()
         pkg = torch.load(str(path))
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-        self.load_state_dict(pkg['model'])
+        self.load_state_dict(pkg['model'], map_location = device)
         return pkg
 
     def forward_with_cond_scale(
@@ -656,13 +657,14 @@ class CoarseTransformer(nn.Module):
     def load(self, path):
         # Return pkg so that if this function gets called from within a Trainer function call,
         # the trainer can also access the package loaded from the checkpoint.
+        device = self.device
         path = Path(path)
         assert path.exists()
         pkg = torch.load(str(path))
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-        self.load_state_dict(pkg['model'])
+        self.load_state_dict(pkg['model'], map_location = device)
         return pkg
 
     def forward_with_cond_scale(
@@ -898,14 +900,16 @@ class FineTransformer(nn.Module):
     def load(self, path):
         # Return pkg so that if this function gets called from within a Trainer function call,
         # the trainer can also access the package loaded from the checkpoint.
+        device = self.device
         path = Path(path)
         assert path.exists()
         pkg = torch.load(str(path))
         # check version
         if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
             print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-        self.load_state_dict(pkg['model'])
+        self.load_state_dict(pkg['model'], map_location = device)
         return pkg
+
 
     def forward_with_cond_scale(
         self,

--- a/audiolm_pytorch/audiolm_pytorch.py
+++ b/audiolm_pytorch/audiolm_pytorch.py
@@ -1165,6 +1165,7 @@ class SemanticTransformerWrapper(nn.Module):
         super().__init__()
         self.wav2vec = wav2vec
         self.transformer = transformer
+        self.to(transformer.device)
         self.audio_conditioner = audio_conditioner
 
         assert not (exists(audio_conditioner) and not transformer.has_condition), 'if conditioning on audio embeddings from mulan, transformer has_condition must be set to True'
@@ -1346,6 +1347,7 @@ class CoarseTransformerWrapper(nn.Module):
         self.wav2vec = wav2vec
 
         self.transformer = transformer
+        self.to(transformer.device)
         self.audio_conditioner = audio_conditioner
 
         assert not (exists(audio_conditioner) and not transformer.has_condition), 'if conditioning on audio embeddings from mulan, transformer has_condition must be set to True'
@@ -1587,6 +1589,7 @@ class FineTransformerWrapper(nn.Module):
         self.codec = codec
 
         self.transformer = transformer
+        self.to(transformer.device)
         self.audio_conditioner = audio_conditioner
 
         assert not (exists(audio_conditioner) and not transformer.has_condition), 'if conditioning on audio embeddings from mulan, transformer has_condition must be set to True'

--- a/audiolm_pytorch/trainer.py
+++ b/audiolm_pytorch/trainer.py
@@ -689,17 +689,9 @@ class SemanticTransformerTrainer(nn.Module):
         torch.save(pkg, path)
 
     def load(self, path):
-        path = Path(path)
-        assert path.exists()
-        pkg = torch.load(str(path), map_location = 'cpu')
-
-        # check version
-
-        if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
-            print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-
         transformer = self.accelerator.unwrap_model(self.transformer)
-        transformer.load_state_dict(pkg['model'])
+        pkg = transformer.load(path)
+        # trainer-specific things
         self.optim.load_state_dict(pkg['optim'])
 
         # + 1 to start from the next step and avoid overwriting the last checkpoint
@@ -946,18 +938,9 @@ class CoarseTransformerTrainer(nn.Module):
         torch.save(pkg, path)
 
     def load(self, path):
-        path = Path(path)
-        assert path.exists()
-        pkg = torch.load(str(path), map_location = 'cpu')
-
-        # check version
-
-        if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
-            print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-
         transformer = self.accelerator.unwrap_model(self.transformer)
-
-        transformer.load_state_dict(pkg['model'])
+        pkg = transformer.load(path)
+        # trainer-specific things
         self.optim.load_state_dict(pkg['optim'])
 
         # + 1 to start from the next step and avoid overwriting the last checkpoint
@@ -1198,19 +1181,11 @@ class FineTransformerTrainer(nn.Module):
         torch.save(pkg, path)
 
     def load(self, path):
-        path = Path(path)
-        assert path.exists()
-        pkg = torch.load(str(path), map_location = 'cpu')
-
-        # check version
-
-        if 'version' in pkg and version.parse(pkg['version']) < version.parse(__version__):
-            print(f'model was trained on older version {pkg["version"]} of audiolm-pytorch')
-
         transformer = self.accelerator.unwrap_model(self.transformer)
-        transformer.load_state_dict(pkg['model'])
-
+        pkg = transformer.load(path)
+        # trainer-specific things
         self.optim.load_state_dict(pkg['optim'])
+
         # + 1 to start from the next step and avoid overwriting the last checkpoint
         self.steps = torch.tensor([checkpoint_num_steps(path) + 1], device=self.device)
 


### PR DESCRIPTION
Since we no longer want to instantiate multiple Trainer instances.

Also fixes a device-related bug in the process (see last commit): 

> This was covered up by previous usage where we'd instantiate trainers for each transformer (semantic/coarse/fine). Now that we have to be able to load transformers without their corresponding trainers, because we can only load one accelerator at a time, the code in trainer that checks wrapper device no longer applies and we get device mismatches. This commit fixes that

--

I tested this code and was able to get a small training run of a few hundred steps working so it works e2e!