### PR TITLE
Bugfix - Fixing validation dataset variable on FineTransformerTrainer

### DIFF
--- a/audiolm_pytorch/trainer.py
+++ b/audiolm_pytorch/trainer.py
@@ -1207,9 +1207,9 @@ class FineTransformerTrainer(nn.Module):
 
         # split for validation
 
-        self.valid_dataset = valid_dataset
+        self.valid_ds = valid_dataset
 
-        if not exists(self.valid_dataset):
+        if not exists(self.valid_ds):
             if valid_frac > 0:
                 train_size = int((1 - valid_frac) * len(self.ds))
                 valid_size = len(self.ds) - train_size


### PR DESCRIPTION
Bugfix addressing [#242](https://github.com/lucidrains/audiolm-pytorch/issues/242)

`valid_dataset` should set `self.valid_ds` to remain consistent with the code, otherwise an error is thrown that `self.valid_ds` doesn't exist.