### PR TITLE
bugfix - swap codec variable for course wrapper

### DIFF
--- a/audiolm_pytorch/audiolm_pytorch.py
+++ b/audiolm_pytorch/audiolm_pytorch.py
@@ -1684,7 +1684,7 @@ class CoarseTransformerWrapper(nn.Module):
 
             coarse_sample_without_padding = rearrange(coarse_sample_without_padding, '... -> 1 ...')
 
-            wav = encodec.decode_from_codebook_indices(coarse_sample_without_padding)
+            wav = self.codec.decode_from_codebook_indices(coarse_sample_without_padding)
             wav = rearrange(wav, '1 1 n -> n')
 
             wavs.append(wav)


### PR DESCRIPTION
quick bugfix responding to [#246 ](https://github.com/lucidrains/audiolm-pytorch/issues/246)

changing `encodec` to `self.codec` 

With this change,  you can `set return_coarse_generated_wave=True` and return just the wave generated by the coarse transformer. 