### PR TITLE
Fix #259

### DIFF
--- a/audiolm_pytorch/trainer.py
+++ b/audiolm_pytorch/trainer.py
@@ -1085,7 +1085,7 @@ class CoarseTransformerTrainer(nn.Module):
             assert not (exists(data_max_length) and exists(data_max_length_seconds))
 
             if exists(data_max_length_seconds):
-                data_max_length = tuple(data_max_length_seconds * hz for hz in (wav2vec.target_sample_hz, codec.target_sample_hz))
+                data_max_length = max(data_max_length_seconds * hz for hz in (wav2vec.target_sample_hz, codec.target_sample_hz))
 
             self.ds = SoundDataset(
                 folder,


### PR DESCRIPTION
This PR fixes #259 by taking
```python
data_max_length = max(data_max_length_seconds * hz for hz in (wav2vec.target_sample_hz, codec.target_sample_hz))
```
In #259 I detail the alternative solution of changing the type of `max_length` in `SoundDataset`. I chose the change in this PR because it is more minimal and type-restrictive in `SoundDataset`, but I welcome feedback/edits if you have a better suggestion.